### PR TITLE
Replace git-gutter with vim-signify

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -40,7 +40,7 @@ call plug#begin(expand('~/.vim/plugged'))
   Plug 'ctrlpvim/ctrlp.vim'
   Plug 'vim-airline/vim-airline'
   Plug 'preservim/nerdtree'
-  Plug 'airblade/vim-gitgutter'
+  Plug 'mhinz/vim-signify'
   Plug 'mattn/emmet-vim'
   Plug 'instant-markdown/vim-instant-markdown', {'for': 'markdown'}
   Plug 'bronson/vim-trailing-whitespace'


### PR DESCRIPTION
git-gutter is an unnecessary resource hog. [Signify](https://github.com/mhinz/vim-signify) is less so and pretty much covers all that git-gutter has to offer. There are differences but compare and see what fits you more :slightly_smiling_face: 